### PR TITLE
Debug prismaclient git workflow configuration

### DIFF
--- a/.github/workflows/client-deploy.yml
+++ b/.github/workflows/client-deploy.yml
@@ -13,6 +13,7 @@ on:
 env:
   EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
   EAS_PROJECT_ID: 12a19ebe-4dc8-457b-99e9-ccc269808a5c
+  BACKEND_HEALTH_URL: ${{ secrets.BACKEND_HEALTH_URL }}
 
 jobs:
   # Job 1: Deploy Client Mobile App (OTA Updates)
@@ -103,11 +104,25 @@ jobs:
 
       - name: Health Check
         run: |
-          sleep 30
-          # Try multiple possible health endpoints
-          curl -f http://${{ secrets.DO_HOST }}:8000/health || \
-          curl -f http://${{ secrets.DO_HOST }}:8000/api/health || \
-          curl -f http://${{ secrets.DO_HOST }}:8000/ || exit 1
+          # configurable health URL, with sensible default
+          url="${BACKEND_HEALTH_URL}"
+          if [ -z "$url" ]; then
+            url="http://${{ secrets.DO_HOST }}:8000/api/v1/health/"
+          fi
+
+          echo "Checking backend health at $url"
+
+          # wait for containers to be ready
+          for i in $(seq 1 20); do
+            if curl -fsS "$url" > /dev/null; then
+              echo "Backend is healthy"
+              exit 0
+            fi
+            echo "Attempt $i failed; retrying in 5s..."
+            sleep 5
+          done
+          echo "Backend did not become healthy in time" >&2
+          exit 1
 
   # Job 3: Run Tests (Optional)
   test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     networks:
       - prisma_shared_net
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/health/"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -43,7 +43,7 @@ services:
     networks:
       - prisma_shared_net
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/api/v1/health/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/server/prisma/main/urls.py
+++ b/server/prisma/main/urls.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.conf.urls.static import static
 from main.views.notifications import NotificationsView
 from main.views.password_reset import RequestPasswordResetView, ResetPasswordView, ValidateResetTokenView, WebResetPasswordView
+from main.views import HealthCheckView
 
 
 app_name = 'main'
@@ -26,6 +27,7 @@ urlpatterns = [
     path('dashboard/<action>/', DashboardView.as_view(), name='dashboard'),
     path('notifications/<action>/', NotificationsView.as_view(), name='notifications'),
     path('terms/<action>/', TermsView.as_view(), name='terms'),
+    path('health/', HealthCheckView.as_view(), name='health'),
     
     # Payment and webhook endpoints
     path('payment/<action>/', PaymentView.as_view(), name='payment'),

--- a/server/prisma/main/views/__init__.py
+++ b/server/prisma/main/views/__init__.py
@@ -1,0 +1,8 @@
+from django.http import JsonResponse
+from django.views import View
+
+
+class HealthCheckView(View):
+    def get(self, request):
+        return JsonResponse({"status": "ok"})
+


### PR DESCRIPTION
Add a dedicated Django health check endpoint and update `docker-compose.yml` and GitHub Actions to use it.

The previous GitHub Actions workflow's "Health Check" step was failing with a 400 error because there was no proper backend health endpoint, causing the `curl` command to hit non-existent paths. This PR fixes that by providing a dedicated health endpoint and making the workflow's health check more resilient.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2b83e46-ec5d-41fc-bf8f-7d233827c6e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d2b83e46-ec5d-41fc-bf8f-7d233827c6e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

